### PR TITLE
[feat][CI] Update clang-format-action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: clang-format Check
-        uses: jidicula/clang-format-action@v1.1.1
+        uses: jidicula/clang-format-action@v2.0.0


### PR DESCRIPTION
Related to jidicula/clang-format-action#18

**Why this change was necessary**
The `master` branch of `clang-format-action` is set to be deleted
on January 15. Additionally, the workflow version in that branch
does **not** support C++ files.

**What this change does**
 - Updates the CI style workflow to point to the earliest version of
 `clang-format-action` supporting C++ files.
 - Uses `checkout@v2`

**Any side-effects?**
Style checks may fail now that C++ files are being checked.

**Additional context/notes/links**
 - https://github.com/jidicula/clang-format-action/releases/tag/v2.0.0

This PR fixes #

Tested with QT version - 

On operating system - 
