### PR TITLE
Fix crash when trying to go to previous image if no image is loaded

### DIFF
--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -171,7 +171,7 @@ void MainWindow::previousImage() {
   int index = fileNames.indexOf(QRegExp(QRegExp::escape(file.fileName())));
   if (index > 0)
     currentFile = dir.absoluteFilePath(fileNames.at(index - 1));
-  else
+  else if(fileNames.size() > 0)
     currentFile = dir.absoluteFilePath(fileNames.at(fileNames.size() - 1));
 
   showImage();


### PR DESCRIPTION
This PR fixes issue #4.

Tested with QT version - 5.15.5

On operating system - Arch Linux
